### PR TITLE
Fix MIDI Timestamps

### DIFF
--- a/midimittr/Info.plist
+++ b/midimittr/Info.plist
@@ -19,11 +19,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.0.7</string>
+	<string>2.0.8</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>50</string>
+	<string>51</string>
 	<key>LSApplicationCategoryType</key>
 	<array>
 		<string></string>

--- a/midimittr/MIDIController.mm
+++ b/midimittr/MIDIController.mm
@@ -7,6 +7,7 @@
 #import "PGMidi.h"
 #import <AVKit/AVKit.h>
 #import <AVFoundation/AVFoundation.h>
+#include <mach/mach_time.h>
 
 id thisClass;
 @interface MIDIController() <PGMidiDelegate, PGMidiSourceDelegate> {
@@ -107,7 +108,8 @@ id thisClass;
     MIDIPacketList* pktList = (MIDIPacketList*) pktBuffer;
     MIDIPacket     *pkt;
     pkt = MIDIPacketListInit(pktList);
-    pkt = MIDIPacketListAdd(pktList, 2048, pkt, 0, packet->length, packet->data);
+    MIDITimeStamp timeStamp = mach_absolute_time();
+    pkt = MIDIPacketListAdd(pktList, 2048, pkt, timeStamp, packet->length, packet->data);
     if (pkt == NULL || MIDIReceived(midiOut, pktList)) {
       NSAssert(true, @"Failed to send MIDI");
     }
@@ -209,7 +211,7 @@ NSString *getDisplayName(MIDIObjectRef object) {
             MIDIPacketList* pktList = (MIDIPacketList*) pktBuffer;
             MIDIPacket *pkt;
             pkt = MIDIPacketListInit(pktList);
-            pkt = MIDIPacketListAdd(pktList, 1024, pkt, 0, packet->length, packet->data);
+            pkt = MIDIPacketListAdd(pktList, 1024, pkt, packet->timeStamp, packet->length, packet->data);
             [dest sendPacketList:pktList];
             packet = MIDIPacketNext(packet);
           }


### PR DESCRIPTION
Previously timestamps were nulled, we are now adding timestamps
manually at the moment they have been received.
This resolves an issue for some users whose apps were reliant on
timestamps for MIDI Clock events.