### PR TITLE
iOS 13 Support / Dark & Light Appearances

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 
-osx_image: xcode10
+osx_image: xcode11
 language: objective-c
 # cache: cocoapods
 # podfile: Example/Podfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ language: objective-c
 # - pod install --project-directory=Example
 script:
 - carthage update
-- set -o pipefail && xcodebuild -project "midimittr.xcodeproj" -target "midimittr" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO
+- set -o pipefail && xcodebuild -project "midimittr.xcodeproj" -target "midimittr" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-github "Daltron/NotificationBanner" "master"
+github "Daltron/NotificationBanner" "2f14c1b2f19cbc783a04f3bd07416fe492e63c06"
 github "rsms/peertalk" "master"

--- a/midimittr.xcodeproj/project.pbxproj
+++ b/midimittr.xcodeproj/project.pbxproj
@@ -36,6 +36,9 @@
 		69B8BA0D19DD8FEF00AB03A2 /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 69B8BA0B19DD8FEF00AB03A2 /* AVFoundation.framework */; settings = {ATTRIBUTES = (Required, ); }; };
 		69B8BA0E19DD8FEF00AB03A2 /* AVKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 69B8BA0C19DD8FEF00AB03A2 /* AVKit.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		69B8BA1019DD99C900AB03A2 /* silence.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = 69B8BA0F19DD99C900AB03A2 /* silence.mp3 */; };
+		69D5406B232B92660005BAC4 /* TabBarExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69D5406A232B92660005BAC4 /* TabBarExtensions.swift */; };
+		69D5406D232B941C0005BAC4 /* NavControllerExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69D5406C232B941C0005BAC4 /* NavControllerExtensions.swift */; };
+		69D5406F232B94A80005BAC4 /* UIColorExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69D5406E232B94A80005BAC4 /* UIColorExtensions.swift */; };
 		69E7A6EA1FF40FD40083EBEE /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69E7A6E91FF40FD40083EBEE /* AppDelegate.swift */; };
 /* End PBXBuildFile section */
 
@@ -81,6 +84,9 @@
 		69B8BA0C19DD8FEF00AB03A2 /* AVKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVKit.framework; path = System/Library/Frameworks/AVKit.framework; sourceTree = SDKROOT; };
 		69B8BA0F19DD99C900AB03A2 /* silence.mp3 */ = {isa = PBXFileReference; lastKnownFileType = audio.mp3; path = silence.mp3; sourceTree = "<group>"; };
 		69CC1D7E1A7B8C4F0054097D /* PTMidimittrProtocol.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PTMidimittrProtocol.h; sourceTree = "<group>"; };
+		69D5406A232B92660005BAC4 /* TabBarExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarExtensions.swift; sourceTree = "<group>"; };
+		69D5406C232B941C0005BAC4 /* NavControllerExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavControllerExtensions.swift; sourceTree = "<group>"; };
+		69D5406E232B94A80005BAC4 /* UIColorExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIColorExtensions.swift; sourceTree = "<group>"; };
 		69E7A6E81FF40FD30083EBEE /* midimittr-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "midimittr-Bridging-Header.h"; sourceTree = "<group>"; };
 		69E7A6E91FF40FD40083EBEE /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -135,7 +141,10 @@
 				69E7A6E91FF40FD40083EBEE /* AppDelegate.swift */,
 				69A79E881FF6686B00A367A4 /* AppContext.swift */,
 				693D9EAF1FF425EF005E899C /* NavController.swift */,
+				69D5406C232B941C0005BAC4 /* NavControllerExtensions.swift */,
 				693D9EB61FF43E10005E899C /* TabController.swift */,
+				69D5406A232B92660005BAC4 /* TabBarExtensions.swift */,
+				69D5406E232B94A80005BAC4 /* UIColorExtensions.swift */,
 				693D9EB41FF42D35005E899C /* MIDIPortsViewController.swift */,
 				69A79E901FF66DA100A367A4 /* USBConnectionTableViewController.swift */,
 				69A79E821FF64FE100A367A4 /* Settings.bundle */,
@@ -328,11 +337,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				693D9EB31FF4267F005E899C /* PeerTalkBridge.m in Sources */,
+				69D5406D232B941C0005BAC4 /* NavControllerExtensions.swift in Sources */,
 				69A79E891FF6686B00A367A4 /* AppContext.swift in Sources */,
 				69AC2C0F19E015D100212353 /* MIDIController.mm in Sources */,
 				69E7A6EA1FF40FD40083EBEE /* AppDelegate.swift in Sources */,
 				693D9EB51FF42D35005E899C /* MIDIPortsViewController.swift in Sources */,
 				693D9EBB1FF446B4005E899C /* BLEClientViewController.swift in Sources */,
+				69D5406B232B92660005BAC4 /* TabBarExtensions.swift in Sources */,
+				69D5406F232B94A80005BAC4 /* UIColorExtensions.swift in Sources */,
 				699BDC6E1FF55D7E00C7057D /* MIDIPortTableCell.swift in Sources */,
 				69A79E911FF66DA100A367A4 /* USBConnectionTableViewController.swift in Sources */,
 				693D9EB01FF425EF005E899C /* NavController.swift in Sources */,

--- a/midimittr.xcodeproj/project.pbxproj
+++ b/midimittr.xcodeproj/project.pbxproj
@@ -488,6 +488,7 @@
 				CODE_SIGN_ENTITLEMENTS = "";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 52;
 				ENABLE_NS_ASSERTIONS = YES;
 				ENABLE_STRICT_OBJC_MSGSEND = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -499,6 +500,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/midimittr/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				MARKETING_VERSION = 2.0.9;
 				OTHER_CFLAGS = "";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.matt.MIDI-LE";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -521,6 +523,7 @@
 				CODE_SIGN_ENTITLEMENTS = "";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CURRENT_PROJECT_VERSION = 52;
 				ENABLE_NS_ASSERTIONS = YES;
 				ENABLE_STRICT_OBJC_MSGSEND = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -532,6 +535,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/midimittr/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				MARKETING_VERSION = 2.0.9;
 				OTHER_CFLAGS = "-DNS_BLOCK_ASSERTIONS=1";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.matt.MIDI-LE";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/midimittr/Info.plist
+++ b/midimittr/Info.plist
@@ -19,11 +19,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.0.8</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>51</string>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>LSApplicationCategoryType</key>
 	<array>
 		<string></string>

--- a/midimittr/NavControllerExtensions.swift
+++ b/midimittr/NavControllerExtensions.swift
@@ -1,0 +1,29 @@
+//  Copyright © 2019 Matthias Frick. All rights reserved.
+
+import Foundation
+
+extension UINavigationController {
+  override open func viewWillLayoutSubviews() {
+    super.viewWillLayoutSubviews()
+    updateAppearance()
+  }
+
+  override public func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+    super.traitCollectionDidChange(previousTraitCollection)
+    updateAppearance()
+  }
+
+  private func updateAppearance() {
+    if #available(iOS 12.0, *) {
+        let userInterfaceStyle = traitCollection.userInterfaceStyle
+        if userInterfaceStyle == .dark {
+          self.navigationBar.tintColor = UIColor.DarkColors.tintColor
+          self.self.navigationBar.backgroundColor = UIColor.DarkColors.backgroundColor
+        }
+        if userInterfaceStyle == .light {
+          self.navigationBar.tintColor = UIColor.LightColors.tintColor
+          self.self.navigationBar.backgroundColor = UIColor.LightColors.backgroundColor
+        }
+    }
+  }
+}

--- a/midimittr/TabBarExtensions.swift
+++ b/midimittr/TabBarExtensions.swift
@@ -1,0 +1,36 @@
+//
+//  TabBarExtensions.swift
+//  midimittr
+//
+//  Created by Matthias Frick on 13/09/2019.
+//  Copyright © 2019 Matthias Frick. All rights reserved.
+//
+
+import Foundation
+
+extension UITabBarController {
+
+  override open func viewWillLayoutSubviews() {
+    super.viewWillLayoutSubviews()
+    updateAppearance()
+  }
+
+  override public func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+    super.traitCollectionDidChange(previousTraitCollection)
+    updateAppearance()
+  }
+
+  private func updateAppearance() {
+    if #available(iOS 12.0, *) {
+        let userInterfaceStyle = traitCollection.userInterfaceStyle
+        if userInterfaceStyle == .dark {
+          self.tabBar.tintColor = UIColor.DarkColors.tintColor
+          self.tabBar.backgroundColor = UIColor.DarkColors.backgroundColor
+        }
+        if userInterfaceStyle == .light {
+          self.tabBar.tintColor = UIColor.LightColors.tintColor
+          self.tabBar.backgroundColor = UIColor.LightColors.backgroundColor
+        }
+    }
+  }
+}

--- a/midimittr/UIColorExtensions.swift
+++ b/midimittr/UIColorExtensions.swift
@@ -1,0 +1,16 @@
+//  Copyright © 2019 Matthias Frick. All rights reserved.
+
+import Foundation
+
+extension UIColor {
+
+  struct DarkColors {
+    static let tintColor = UIColor.white
+    static let backgroundColor = UIColor.black
+  }
+
+  struct LightColors {
+    static let tintColor = UIColor.systemBlue
+    static let backgroundColor = UIColor.white
+  }
+}


### PR DESCRIPTION
Compile against iOS 13 SDK, add support for dark and light appearances while maintaining iOS 9 compatibility.
This required using a commit id from the NotificationBanner dependency as they have dropped iOS 9.